### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Allstate Purchase Prediction Challenge
+## Allstate Purchase Prediction Challenge
 
 ### Requirements
 Python 2.7.5 with Scikit-Learn 0.14a1, Numpy 1.8, Pandas 0.12<br>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
